### PR TITLE
Project setup: Fixed tyescript config jest types

### DIFF
--- a/li-frontend/components/__tests__/Greeting.test.tsx
+++ b/li-frontend/components/__tests__/Greeting.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react-native";
-import Greeting from "../Greeting.tsx";
+import Greeting from "../Greeting";
 
 describe("Greeting Component", () => {
   it("renders the correct name", () => {

--- a/li-frontend/package-lock.json
+++ b/li-frontend/package-lock.json
@@ -39,6 +39,7 @@
         "@babel/core": "^7.25.2",
         "@testing-library/jest-native": "^5.4.3",
         "@testing-library/react-native": "^13.2.0",
+        "@types/jest": "^29.5.14",
         "@types/react": "~19.0.10",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
@@ -3379,6 +3380,16 @@
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/jsdom": {

--- a/li-frontend/package.json
+++ b/li-frontend/package.json
@@ -44,6 +44,7 @@
     "@babel/core": "^7.25.2",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.2.0",
+    "@types/jest": "^29.5.14",
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",


### PR DESCRIPTION
## Description

This PR configures TypeScript to recognize Jest global functions such as `describe`, `test`, and `expect`.

### Key changes:
- Added `@types/jest` to `devDependencies`
- Updated `tsconfig.json` to include `"jest"` in the `types` array under `compilerOptions`

This resolves the error:
> Cannot find name 'describe'. Do you need to install type definitions for a test runner?

## How was it tested?
- [x] Manual tests
- [n/a] Unit tests

## Checklist
- [x] Code does not generate new warnings
- [x] I have self-reviewed my code
